### PR TITLE
Update APIs to 7.x version

### DIFF
--- a/ida_settings/ida_settings.py
+++ b/ida_settings/ida_settings.py
@@ -422,7 +422,7 @@ class UserIDASettings(IDASettingsBase, DictMixin):
 
 def get_directory_config_path(directory=None):
     if directory is None:
-        directory = os.path.dirname(idc.GetIdbPath())
+        directory = os.path.dirname(idc.get_idb_path())
     config_path = os.path.join(directory, CONFIG_FILE_NANE)
     return config_path
 


### PR DESCRIPTION
With IDA7.4, IDA is dropping backwards compatibility for 6.x APIs.
https://www.hex-rays.com/products/ida/support/ida74_idapython_no_bc695.shtml