### PR TITLE
plugin: add ida_settings_show IDC function

### DIFF
--- a/ida-plugin.json
+++ b/ida-plugin.json
@@ -2,7 +2,7 @@
   "IDAMetadataDescriptorVersion": 1,
   "plugin": {
     "name": "ida-settings-editor",
-    "version": "1.2.0",
+    "version": "1.2.1",
     "description": "Settings manager UI for IDA Pro plugins",
     "entryPoint": "./plugin/entrypoint.py",
     "authors": [{"name": "Willi Ballenthin", "email": "wballenthin@hex-rays.com"}],

--- a/ida-plugin.json
+++ b/ida-plugin.json
@@ -2,7 +2,7 @@
   "IDAMetadataDescriptorVersion": 1,
   "plugin": {
     "name": "ida-settings-editor",
-    "version": "1.1.1",
+    "version": "1.2.0",
     "description": "Settings manager UI for IDA Pro plugins",
     "entryPoint": "./plugin/entrypoint.py",
     "authors": [{"name": "Willi Ballenthin", "email": "wballenthin@hex-rays.com"}],

--- a/plugin/entrypoint.py
+++ b/plugin/entrypoint.py
@@ -16,10 +16,14 @@ def should_load():
         return False
 
     kernel_version: tuple[int, ...] = tuple(
-        int(part) for part in ida_kernwin.get_kernel_version().split(".") if part.isdigit()
+        int(part)
+        for part in ida_kernwin.get_kernel_version().split(".")
+        if part.isdigit()
     ) or (0,)
     if kernel_version < (9, 0):
-        logger.warning("IDA too old (must be 9.0+): %s", ida_kernwin.get_kernel_version())
+        logger.warning(
+            "IDA too old (must be 9.0+): %s", ida_kernwin.get_kernel_version()
+        )
         return False
 
     return True
@@ -128,8 +132,12 @@ if should_load():
             )
 
         def _unregister_actions(self):
-            ida_kernwin.detach_action_from_menu(self.MENU_PATH_PLUGINS, self.ACTION_NAME)
-            ida_kernwin.detach_action_from_menu(self.MENU_PATH_SUBVIEWS, self.ACTION_NAME)
+            ida_kernwin.detach_action_from_menu(
+                self.MENU_PATH_PLUGINS, self.ACTION_NAME
+            )
+            ida_kernwin.detach_action_from_menu(
+                self.MENU_PATH_SUBVIEWS, self.ACTION_NAME
+            )
             ida_kernwin.unregister_action(self.ACTION_NAME)
 
         def _register_idc_func(self):
@@ -137,7 +145,9 @@ if should_load():
                 self.show_settings_manager(plugin_name)
                 return plugin_name
 
-            if ida_expr.add_idc_func(self.IDC_FUNC_NAME, idc_show_settings, (ida_expr.VT_STR,)):
+            if ida_expr.add_idc_func(
+                self.IDC_FUNC_NAME, idc_show_settings, (ida_expr.VT_STR,)
+            ):
                 logger.debug("registered %s IDC function", self.IDC_FUNC_NAME)
             else:
                 logger.warning("failed to register %s IDC function", self.IDC_FUNC_NAME)

--- a/plugin/entrypoint.py
+++ b/plugin/entrypoint.py
@@ -102,7 +102,7 @@ if should_load():
             self.form_registry: dict[str, settings_manager_form_t] = {}
             self.init()
 
-        IDC_FUNC_NAME = "ida_settings_show"
+        IDC_FUNC_NAME = "ida_settings_show_plugin_settings"
 
         def init(self):
             self._register_actions()

--- a/plugin/entrypoint.py
+++ b/plugin/entrypoint.py
@@ -1,6 +1,7 @@
 import logging
 import os
 
+import ida_expr
 import ida_idaapi
 import ida_kernwin
 
@@ -26,8 +27,10 @@ def should_load():
 
 if should_load():
     try:
+        from PyQt5.QtCore import Qt
         from PyQt5.QtWidgets import QVBoxLayout
     except ImportError:
+        from PySide6.QtCore import Qt
         from PySide6.QtWidgets import QVBoxLayout
 
     from settings_editor.controller import SettingsController
@@ -64,6 +67,15 @@ if should_load():
             if self.form_registry is not None:
                 self.form_registry[self.TITLE] = self
 
+        def select_plugin(self, plugin_name: str) -> bool:
+            if self.view is None:
+                return False
+            items = self.view.plugin_list.findItems(plugin_name, Qt.MatchExactly)
+            if not items:
+                return False
+            self.view.plugin_list.setCurrentItem(items[0])
+            return True
+
         def OnClose(self, form):
             if self.form_registry is not None:
                 self.form_registry.pop(self.TITLE, None)
@@ -90,8 +102,11 @@ if should_load():
             self.form_registry: dict[str, settings_manager_form_t] = {}
             self.init()
 
+        IDC_FUNC_NAME = "ida_settings_show"
+
         def init(self):
             self._register_actions()
+            self._register_idc_func()
 
         def _register_actions(self):
             action_desc = ida_kernwin.action_desc_t(
@@ -117,13 +132,28 @@ if should_load():
             ida_kernwin.detach_action_from_menu(self.MENU_PATH_SUBVIEWS, self.ACTION_NAME)
             ida_kernwin.unregister_action(self.ACTION_NAME)
 
-        def show_settings_manager(self):
+        def _register_idc_func(self):
+            def idc_show_settings(plugin_name: str) -> str:
+                self.show_settings_manager(plugin_name)
+                return plugin_name
+
+            if ida_expr.add_idc_func(self.IDC_FUNC_NAME, idc_show_settings, (ida_expr.VT_STR,)):
+                logger.debug("registered %s IDC function", self.IDC_FUNC_NAME)
+            else:
+                logger.warning("failed to register %s IDC function", self.IDC_FUNC_NAME)
+
+        def _unregister_idc_func(self):
+            ida_expr.del_idc_func(self.IDC_FUNC_NAME)
+
+        def show_settings_manager(self, plugin_name: str = ""):
             caption = "Plugin Settings Manager"
 
             if caption in self.form_registry:
                 widget = ida_kernwin.find_widget(caption)
                 if widget:
                     ida_kernwin.activate_widget(widget, True)
+                    if plugin_name:
+                        self.form_registry[caption].select_plugin(plugin_name)
                     return
 
             form = settings_manager_form_t(caption, self.form_registry)
@@ -137,11 +167,15 @@ if should_load():
                 ),
             )
 
+            if plugin_name:
+                form.select_plugin(plugin_name)
+
         def run(self, arg):
             self.show_settings_manager()
             return True
 
         def term(self):
+            self._unregister_idc_func()
             self._unregister_actions()
 
     class settings_editor_plugin_t(ida_idaapi.plugin_t):

--- a/plugin/main.py
+++ b/plugin/main.py
@@ -12,7 +12,6 @@ Usage:
 import sys
 
 try:
-    from PyQt5.QtCore import Qt
     from PyQt5.QtWidgets import QApplication, QVBoxLayout, QWidget
 except ImportError:
     from PySide6.QtWidgets import QApplication, QVBoxLayout, QWidget

--- a/plugin/settings_editor/view.py
+++ b/plugin/settings_editor/view.py
@@ -3,10 +3,8 @@
 try:
     from PyQt5.QtCore import Qt
     from PyQt5.QtCore import pyqtSignal as Signal
-    from PyQt5.QtGui import QIcon
     from PyQt5.QtWidgets import (
         QComboBox,
-        QFormLayout,
         QHBoxLayout,
         QLabel,
         QLineEdit,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ida-settings"
-version = "3.4.1"
+version = "3.5.0"
 description = "Fetch configuration values for IDA Pro plugins"
 readme = "readme.md"
 authors = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ida-settings"
-version = "3.5.0"
+version = "3.5.1"
 description = "Fetch configuration values for IDA Pro plugins"
 readme = "readme.md"
 authors = [

--- a/readme.md
+++ b/readme.md
@@ -60,5 +60,5 @@ Other plugins can open the settings UI focused on a specific plugin via IDC:
 
 ```py
 import idc
-idc.eval_idc('ida_settings_show("my-plugin-name")')
+idc.eval_idc('ida_settings_show_plugin_settings("my-plugin-name")')
 ```

--- a/readme.md
+++ b/readme.md
@@ -55,3 +55,10 @@ hcli plugin install ida-settings-editor
 Open via:
 - Edit → Plugins → Plugin Settings Manager
 - View → Open subviews → Plugin Settings Manager
+
+Other plugins can open the settings UI focused on a specific plugin via IDC:
+
+```py
+import idc
+idc.eval_idc('ida_settings_show("my-plugin-name")')
+```

--- a/src/ida_settings/legacy.py
+++ b/src/ida_settings/legacy.py
@@ -91,7 +91,7 @@ import sys
 import warnings
 
 try:
-    import idaapi
+    import idaapi  # noqa: F401
     import idc
     import netnode
 except ImportError:
@@ -180,7 +180,7 @@ def validate_value(value):
 
     try:
         _ = json.dumps(value)
-    except:
+    except Exception:
         raise TypeError("value cannot be json encoded")
 
 
@@ -598,8 +598,8 @@ class IDBIDASettings(IDASettingsBase, DictMixin):
 
 def ensure_ida_loaded():
     try:
-        import idaapi
-        import idc
+        import idaapi  # noqa: F401
+        import idc  # noqa: F401
     except ImportError:
         raise EnvironmentError(
             "Must be running in IDA to access IDB or directory settings"


### PR DESCRIPTION
## Summary

- Registers an `ida_settings_show` IDC function that other plugins can call to open the settings UI focused on a specific plugin
- Adds `select_plugin` method to the form for programmatic plugin selection via `QListWidget.findItems`
- Follows the pairwise register/unregister pattern for IDC function lifecycle

Example usage from another plugin:
```python
import idc
idc.eval_idc('ida_settings_show("my-virustotal-plugin")')
```

Closes #24

## Test plan

- [ ] Install the plugin, verify it loads without errors
- [ ] Call `idc.eval_idc('ida_settings_show("some-plugin")')` from the IDA console — settings UI should open with that plugin selected
- [ ] Call with an empty string — settings UI should open with no specific selection
- [ ] Call when the settings UI is already open — it should activate and switch to the requested plugin
- [ ] Verify the IDC function is cleaned up on plugin unload (no stale registration)

🤖 Generated with [Claude Code](https://claude.com/claude-code)